### PR TITLE
Pass Verilator include directory to dependencies.

### DIFF
--- a/test/alu/alu.cpp
+++ b/test/alu/alu.cpp
@@ -1,4 +1,4 @@
-#include "test/alu/Valu.h/Valu.h"
+#include "Valu.h"
 
 int main() {
   Valu alu;

--- a/verilator/defs.bzl
+++ b/verilator/defs.bzl
@@ -147,6 +147,7 @@ def _verilator_cc_library(ctx):
         srcs = srcs,
         hdrs = hdrs,
         defines = defines,
+        includes = [verilator_output_hpp.path],
         deps = deps,
     )
 

--- a/verilator/internal/cc_actions.bzl
+++ b/verilator/internal/cc_actions.bzl
@@ -92,7 +92,7 @@ def _link_static_library(
         ),
     )
 
-def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, defines = []):
+def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, includes = [], defines = []):
     """Compile and link C++ source into a static library"""
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
@@ -109,6 +109,7 @@ def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, defines = []):
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
         srcs = srcs,
+        includes = includes,
         defines = defines,
         public_hdrs = hdrs,
         compilation_contexts = compilation_contexts,


### PR DESCRIPTION
This change places the generated module's include directory on the
search path during compilation of dependencies.  The benefit of this is
two fold: first it allows the application code to avoid the odd
directory naming (V{module}.h/...) required for tree artifacts, second
it paves the way for multiple verilog_cc_libraries which contain the
same top module but are compiled differently (i.e. different params such
as -GW=16).  In this case the application simply includes V{module}.h
and the correct include directory is choosen based on the BUILD rules.