### PR TITLE
Add support for `verilog_module` from `rules_verilog`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,27 @@ cc_binary(
 )
 ```
 
-Verilog libraries can also be specifed as dependencies
+The details of a verilog module (sources, top name, etc.) can also be specified by a `verilog_module`
+which can be reused in other rules.
 
 ```python
-load("@rules_verilator//verilator:defs.bzl", "sv_library", "verilator_cc_library")
+load("@rules_verilog//verilog:defs.bzl", "verilog_module")
 
-sv_library(
-    name = "alu_lib",
+load("@rules_verilator//verilator:defs.bzl", "verilator_cc_library")
+
+verilog_module(
+    name = "alu_module",
+    top = "alu",
     srcs = ["alu.sv"],
 )
 
 verilator_cc_library(
     name = "alu",
-    mtop = "alu",
-    deps = [":alu_lib"],
+    module = ":alu_module",
 )
 ```
+
+See [test/alu/BUILD](test/alu/BUILD) for working examples.
 
 ## License
 

--- a/test/alu/BUILD
+++ b/test/alu/BUILD
@@ -34,5 +34,4 @@ cc_binary(
     name = "alu_bin_with_module",
     srcs = ["alu.cpp"],
     deps = [":alu_with_module"],
-    local_defines = ["WITH_MODULE"],
 )

--- a/test/alu/BUILD
+++ b/test/alu/BUILD
@@ -1,3 +1,5 @@
+load("@rules_verilog//verilog:defs.bzl", "verilog_module")
+
 load("@rules_verilator//verilator:defs.bzl", "sv_library", "verilator_cc_library")
 
 sv_library(
@@ -15,4 +17,22 @@ cc_binary(
     name = "alu_bin",
     srcs = ["alu.cpp"],
     deps = [":alu"],
+)
+
+verilog_module(
+    name = "alu_module",
+    top = "alu",
+    srcs = ["alu.sv"],
+)
+
+verilator_cc_library(
+    name = "alu_with_module",
+    module = ":alu_module",
+)
+
+cc_binary(
+    name = "alu_bin_with_module",
+    srcs = ["alu.cpp"],
+    deps = [":alu_with_module"],
+    local_defines = ["WITH_MODULE"],
 )

--- a/verilator/repositories.bzl
+++ b/verilator/repositories.bzl
@@ -62,6 +62,13 @@ def rules_verilator_dependencies(version = _DEFAULT_VERSION):
         urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.1/rules_bison-v0.1.tar.xz"],
         sha256 = "5c57552a129b0d8eeb9252341ee975ec2720c35baf2f0d154756310c1ff572a0",
     )
+    _maybe(
+        http_archive,
+        name = "rules_verilog",
+        urls = ["https://github.com/agoessling/rules_verilog/archive/v0.1.0.zip"],
+        strip_prefix = "rules_verilog-0.1.0",
+        sha256 = "401b3f591f296f6fd2f6656f01afc1f93111e10b81b9a9d291f9c04b3e4a3e8b",
+    )
 
 def rules_verilator_toolchains(version = _DEFAULT_VERSION):
     repo_name = "verilator_v{version}".format(version = version)


### PR DESCRIPTION
`verilog_module` provides a concise way to provide
`verilator_cc_library` the verilog sources, dependencies, and top
module name of a verilog module.