### PR TITLE
Force unused variables to be a warning instead of an error in Verilator build.

### DIFF
--- a/verilator/internal/verilator.BUILD
+++ b/verilator/internal/verilator.BUILD
@@ -216,7 +216,7 @@ cc_library(
         "include/gtkwave/lz4.c",
     ],
     visibility = ["//visibility:public"],
-    copts = ["-Wno-unused-variable"],
+    copts = ["-Wno-unused-const-variable"],
 )
 
 cc_library(

--- a/verilator/internal/verilator.BUILD
+++ b/verilator/internal/verilator.BUILD
@@ -216,6 +216,7 @@ cc_library(
         "include/gtkwave/lz4.c",
     ],
     visibility = ["//visibility:public"],
+    copts = ["-Wno-unused-variable"],
 )
 
 cc_library(

--- a/verilator/internal/verilator.BUILD
+++ b/verilator/internal/verilator.BUILD
@@ -216,6 +216,7 @@ cc_library(
         "include/gtkwave/lz4.c",
     ],
     visibility = ["//visibility:public"],
+    # TODO: Remove these once upstream fixes these warnings
     copts = ["-Wno-unused-const-variable"],
 )
 


### PR DESCRIPTION
If a repo is setup to treat unused variables as errors, this build of Verilator will fail. This PR adds a `copt` to the `cc_library` which forces unused variables to be treated as errors. This will locally override any more restrictive build options defined at a higher level.

Error:

```
Use --sandbox_debug to see verbose messages from the sandbox
external/verilator_v4.218/include/verilated_vcd_c.cpp:56:20: error: unused variable 'VL_TRACE_MAX_VCD_CODE_SIZE' [-Werror,-Wunused-const-variable]
constexpr unsigned VL_TRACE_MAX_VCD_CODE_SIZE = 5;  // Maximum length of a VCD string code
```