### PR TITLE
fix m4 build issues in latest libc

### DIFF
--- a/verilator/repositories.bzl
+++ b/verilator/repositories.bzl
@@ -54,8 +54,8 @@ def rules_verilator_dependencies(version = _DEFAULT_VERSION):
     _maybe(
         http_archive,
         name = "rules_m4",
-        urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2/rules_m4-v0.2.tar.xz"],
-        sha256 = "c67fa9891bb19e9e6c1050003ba648d35383b8cb3c9572f397ad24040fb7f0eb",
+        urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.2/rules_m4-v0.2.2.tar.xz"],
+        sha256 = "b0309baacfd1b736ed82dc2bb27b0ec38455a31a3d5d20f8d05e831ebeef1a8e",
     )
     _maybe(
         http_archive,
@@ -66,8 +66,8 @@ def rules_verilator_dependencies(version = _DEFAULT_VERSION):
     _maybe(
         http_archive,
         name = "rules_bison",
-        urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2/rules_bison-v0.2.tar.xz"],
-        sha256 = "6ee9b396f450ca9753c3283944f9a6015b61227f8386893fb59d593455141481",
+        urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2.1/rules_bison-v0.2.1.tar.xz"],
+        sha256 = "9577455967bfcf52f9167274063ebb74696cb0fd576e4226e14ed23c5d67a693",
     )
     _maybe(
         http_archive,


### PR DESCRIPTION
The m4 version used does not work with the latest Linux libc. There is a patch in the jmillikin rules_m4. This pull request updated to the latest version (which has the patch).

This is the error that I get now:
``` bazel build //test/alu:alu_bin
WARNING: Output base '/mada/users/renau/.cache/bazel/_bazel_renau/5d8c8ff00e63488a1c5a6f72afddef86' is on NFS. This may lead to surprising failures and undetermined behavior.
INFO: Analyzed target //test/alu:alu_bin (60 packages loaded, 1199 targets configured).
INFO: Found 1 target...
ERROR: /mada/users/renau/.cache/bazel/_bazel_renau/5d8c8ff00e63488a1c5a6f72afddef86/external/m4_v1.4.18/gnulib/BUILD.bazel:192:11: Compiling gnulib/lib/c-stack.c [for host] failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 25 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from /usr/include/signal.h:328,
                 from external/m4_v1.4.18/gnulib/lib/c-stack.c:49:
external/m4_v1.4.18/gnulib/lib/c-stack.c:55:26: error: missing binary operator before token "("
   55 | #elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384
      |                          ^~~~~~~~
external/m4_v1.4.18/gnulib/lib/c-stack.c:139:8: error: variably modified 'buffer' at file scope
  139 |   char buffer[SIGSTKSZ];
      |        ^~~~~~
Target //test/alu:alu_bin failed to build
```

The error is gone after this pull request.
