### PR TITLE
Fix warnings, give access to linker flags

### DIFF
--- a/verilator/defs.bzl
+++ b/verilator/defs.bzl
@@ -153,7 +153,6 @@ def _verilator_cc_library(ctx):
     deps = list(verilator_toolchain.libs)
     #if ctx.attr.sysc:
     #    deps.append(ctx.attr._systemc)
-
     return cc_compile_and_link_static_library(
         ctx,
         srcs = srcs,
@@ -161,6 +160,8 @@ def _verilator_cc_library(ctx):
         defines = defines,
         includes = [verilator_output_hpp.path],
         deps = deps,
+        user_compile_flags=ctx.attr.user_compile_flags,
+        user_link_flags=ctx.attr.user_link_flags,
     )
 
 verilator_cc_library = rule(
@@ -201,6 +202,14 @@ verilator_cc_library = rule(
         "vopts": attr.string_list(
             doc = "Additional command line options to pass to Verilator",
             default = ["-Wall"],
+        ),
+        "user_compile_flags": attr.string_list(
+            doc = "Additional command line options to pass to C++ compiler",
+            default = [],
+        ),
+        "user_link_flags": attr.string_list(
+            doc = "Additional command line options to pass to Linker",
+            default = [],
         ),
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),

--- a/verilator/internal/cc_actions.bzl
+++ b/verilator/internal/cc_actions.bzl
@@ -2,7 +2,8 @@
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
-def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, includes = [], defines = []):
+def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, includes = [], defines = [],
+    user_compile_flags = [], user_link_flags = []):
     """Compile and link C++ source into a static library"""
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
@@ -23,6 +24,7 @@ def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, includes = [], def
         defines = defines,
         public_hdrs = hdrs,
         compilation_contexts = compilation_contexts,
+        user_compile_flags = user_compile_flags,
     )
 
     linking_contexts = [dep[CcInfo].linking_context for dep in deps]
@@ -33,6 +35,7 @@ def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, includes = [], def
         compilation_outputs = compilation_outputs,
         linking_contexts = linking_contexts,
         name = ctx.label.name,
+        user_link_flags = user_link_flags,
     )
 
     output_files = []

--- a/verilator/internal/verilator.BUILD
+++ b/verilator/internal/verilator.BUILD
@@ -217,7 +217,11 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     # TODO: Remove these once upstream fixes these warnings
-    copts = ["-Wno-unused-const-variable"],
+    copts = [
+        "-Wno-unused-const-variable",
+        "-Wno-deprecated-declarations",
+        "-Wno-unused-but-set-variable",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
I noticed a couple of issues when compiling with `-Wall,-Werror` on macOS. With this change we:

- work around the issue
  ```bash
   external/verilator_v4.218/include/gtkwave/fstapi.c:6008:14: error: variable 'secnum' set but not used [-Werror,-Wunused-but-set-variable]
  unsigned int secnum = 0;
  ```
- allow users to specify user compile and link flags; I use this to pass `-W-no...` flags in case the generated code would fail compilation with `-Werror`